### PR TITLE
Readme function names formatted consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,15 @@ Rendered Texture as polygon with sides increasing:
 
 ## Functions:
 
-bool **SDL2_RenderParty_Init();  //optional   
+**bool SDL2_RenderParty_Init**();  //optional   
   
-bool **SDL2_RenderParty_Quit(); //optional   
+**bool SDL2_RenderParty_Quit**(); //optional   
   
 //Gets the Directional Length on the X Axis , used in other calls  
-float **SDL2_RenderParty_LengthdirX( float length, float angle  );  
+**float SDL2_RenderParty_LengthdirX( float length, float angle  );  
   
 //Gets the Directional Length on the Y Axis , used in other calls   
-float **SDL2_RenderParty_LengthdirY**( float length, float angle  );   
+**float SDL2_RenderParty_LengthdirY**( float length, float angle  );   
   
   
 // Renders a texture or rotated rectangle based on 4 SDL_Vertices, you may toggle colors on or off and correct the inputted texture coordinates   

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Rendered Texture as polygon with sides increasing:
 **bool SDL2_RenderParty_Quit**(); //optional   
   
 //Gets the Directional Length on the X Axis , used in other calls  
-**float SDL2_RenderParty_LengthdirX( float length, float angle  );  
+**float SDL2_RenderParty_LengthdirX**( float length, float angle  );  
   
 //Gets the Directional Length on the Y Axis , used in other calls   
 **float SDL2_RenderParty_LengthdirY**( float length, float angle  );   


### PR DESCRIPTION
The README's function names were inconsistenly formatted, and 3 of them look they're returning a pointer to a pointer. The PR fixes that formatting

Original
![image](https://github.com/pawbyte/SDL2_RenderParty/assets/49015102/9ac6c59c-6def-4723-b838-f63b8df723e4)

New
![image](https://github.com/pawbyte/SDL2_RenderParty/assets/49015102/5179c15c-2e9e-4691-93ee-e8cfdef3e17d)
